### PR TITLE
Fix supported versions of OCaml in Docker-Coq

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ opam remove foo
 
 ### `ocaml-version`
 
-*Optional* The version of OCaml. Default `"4.05"`. Among
-`"4.05"`, `"4.07-flambda"`, `"4.09-flambda"`.
+*Optional* The version of OCaml. Default `"minimal"`.
+Among `"minimal"`, `"4.07-flambda"`, `"4.09-flambda"`.
 
 ### `custom-script`
 

--- a/action.yml
+++ b/action.yml
@@ -9,8 +9,8 @@ inputs:
     description: '"8.X", "latest", or "dev".'
     default: 'latest'
   ocaml-version:
-    description: '4.05, 4.07-flambda, or 4.09-flambda'
-    default: '4.05'
+    description: 'minimal, 4.07-flambda, or 4.09-flambda'
+    default: 'minimal'
   custom-script:
     description: 'The main script run in the container; may be overridden.'
     default: |

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -106,6 +106,7 @@ if [ "$_OCAML_VERSION" = '4.09-flambda' ]; then
     COQ_IMAGE="${COQ_IMAGE}-ocaml-4.09.0-flambda"
 elif [ "$_OCAML_VERSION" = '4.07-flambda' ]; then
     OCAML407="true"
+# else Assume "$_OCAML_VERSION" = 'minimal'
 fi
 echo OCAML407="$OCAML407"
 


### PR DESCRIPTION
@Zimmi48 formally speaking, the `4.02.3` version of OCaml was missing

See: https://github.com/coq-community/docker-coq/wiki#supported-tags