### PR TITLE
fix: use underscores

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,21 +20,21 @@ opam remove foo
 
 ## Inputs
 
-### `opam-file`
+### `opam_file`
 
 **Required** the path of the `.opam` file, relative to the repo root.
 
-### `coq-version`
+### `coq_version`
 
 *Optional* The version of Coq. E.g., `"8.10"`. Default
 `"latest"` (= latest stable version).
 
-### `ocaml-version`
+### `ocaml_version`
 
 *Optional* The version of OCaml. Default `"minimal"`.
 Among `"minimal"`, `"4.07-flambda"`, `"4.09-flambda"`.
 
-### `custom-script`
+### `custom_script`
 
 *Optional* The main script run in the container; may be overridden. Default:
 
@@ -55,16 +55,16 @@ option might be removed, or replaced with other similar options.*
 ```yaml
 uses: erikmd/docker-coq-action@alpha
 with:
-  opam-file: 'foo.opam'
-  coq-version: 'dev'
-  ocaml-version: '4.07-flambda'
+  opam_file: 'foo.opam'
+  coq_version: 'dev'
+  ocaml_version: '4.07-flambda'
 ```
 
 ## TODO/IFNEEDBE
 
 * We should document the contents/generation of a Coq `.opam` file
   (e.g., with a link to coq-community templates)
-* We might want to replace the `custom-script` option with `script`,
+* We might want to replace the `custom_script` option with `script`,
   `after_script`, etc.
 * We might want to allow the user to override the name of the
   underlying (docker-coq) image

--- a/action.yml
+++ b/action.yml
@@ -2,16 +2,16 @@ name: 'Docker-Coq Action'
 description: 'GitHub Action using Docker-Coq'
 author: 'Erik Martin-Dorel'
 inputs:
-  opam-file:
+  opam_file:
     description: 'The path of the .opam file, relative to the repo root.'
     required: true
-  coq-version:
+  coq_version:
     description: '"8.X", "latest", or "dev".'
     default: 'latest'
-  ocaml-version:
+  ocaml_version:
     description: 'minimal, 4.07-flambda, or 4.09-flambda'
     default: 'minimal'
-  custom-script:
+  custom_script:
     description: 'The main script run in the container; may be overridden.'
     default: |
       opam config list; opam repo list; opam list
@@ -25,10 +25,10 @@ runs:
   image: 'Dockerfile'
   args:
     - '-f'
-    - ${{ inputs.opam-file }}
+    - ${{ inputs.opam_file }}
     - '-c'
-    - ${{ inputs.coq-version }}
+    - ${{ inputs.coq_version }}
     - '-m'
-    - ${{ inputs.ocaml-version }}
+    - ${{ inputs.ocaml_version }}
     - '-s'
-    - ${{ inputs.custom-script }}
+    - ${{ inputs.custom_script }}


### PR DESCRIPTION
just a heads-up PR.

Motivation for this non-backward-compatible change: the input parameters are also passed as *environment variables* to the outer container:

> Excerpt from https://github.com/erikmd/docker-coq-github-action-demo/runs/535378260:
>
>Run erikmd/docker-coq-action@alpha  
> $ /usr/bin/docker run --name …_… --label … --workdir /github/workspace --rm -e INPUT_OPAM-FILE -e INPUT_COQ-VERSION -e INPUT_OCAML-VERSION -e INPUT_CUSTOM-SCRIPT -e HOME (…)

but dashes in variable names is not supported by POSIX nor by recent versions of `bash`, see e.g. https://stackoverflow.com/q/36989263