### PR TITLE
Support coq-problem-matcher

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@
 !README.md
 !entrypoint.sh
 !timegroup.sh
+!coq.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,6 @@ COPY LICENSE README.md ./
 
 COPY entrypoint.sh timegroup.sh ./
 
+COPY coq.json ./
+
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ it will run (by default) the following commands:
 opam config list; opam repo list; opam list
 opam pin add -n -y -k path coq-proj folder
 opam update -y
+opam install -y -j 2 coq-proj --deps-only
 opam install -y -v -j 2 coq-proj
 opam list
 opam remove coq-proj
@@ -96,9 +97,10 @@ Among `"minimal"`, `"4.07-flambda"`, `"4.09-flambda"`.
 startGroup Print opam config
   opam config list; opam repo list; opam list
 endGroup
-startGroup Fetch dependencies
+startGroup Build dependencies
   opam pin add -n -y -k path $PACKAGE $WORKDIR
   opam update -y
+  opam install -y -j 2 $PACKAGE --deps-only
 endGroup
 startGroup Build
   opam install -y -v -j 2 $PACKAGE

--- a/action.yml
+++ b/action.yml
@@ -20,9 +20,10 @@ inputs:
       startGroup Print opam config
         opam config list; opam repo list; opam list
       endGroup
-      startGroup Fetch dependencies
+      startGroup Build dependencies
         opam pin add -n -y -k path $PACKAGE $WORKDIR
         opam update -y
+        opam install -y -j 2 $PACKAGE --deps-only
       endGroup
       startGroup Build
         opam install -y -v -j 2 $PACKAGE

--- a/coq.json
+++ b/coq.json
@@ -1,0 +1,21 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "coq-problem-matcher",
+            "pattern": [
+                {
+                    "regexp": "^File \"([^ \"]+)\", line (\\d+), characters (\\d+-\\d+):",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3
+                },
+                {
+                    "regexp": "^(Warning|Error):\\s*(.*?)(?:\\s*\\[(.*)\\])?$",
+                    "severity": 1,
+                    "message": 2,
+                    "code": 3
+                }
+            ]
+        }
+    ]
+}

--- a/coq.json
+++ b/coq.json
@@ -4,13 +4,13 @@
             "owner": "coq-problem-matcher",
             "pattern": [
                 {
-                    "regexp": "^File \"([^ \"]+)\", line (\\d+), characters (\\d+-\\d+):",
+                    "regexp": "^(?:-\\s+)?File \"([^ \"]+)\", line (\\d+), characters (\\d+-\\d+):",
                     "file": 1,
                     "line": 2,
                     "column": 3
                 },
                 {
-                    "regexp": "^(Warning|Error):\\s*(.*?)(?:\\s*\\[(.*)\\])?$",
+                    "regexp": "^(?:-\\s+)?(Warning|Error):\\s*(.*?)(?:\\s*\\[(.*)\\])?$",
                     "severity": 1,
                     "message": 2,
                     "code": 3

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,6 +22,7 @@ echo "RUNNER_WORKSPACE=$RUNNER_WORKSPACE"
 # https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables
 HOST_WORKSPACE_REPO="${RUNNER_WORKSPACE}/${GITHUB_REPOSITORY#*/}"
 echo "HOST_WORKSPACE_REPO=$HOST_WORKSPACE_REPO"
+echo "HOME=$HOME"
 echo
 
 echo "INPUT_COQ_VERSION=$INPUT_COQ_VERSION"
@@ -141,6 +142,9 @@ else
     _OCAML407_COMMAND=''
 fi
 
+cp /app/coq.json ./coq.json
+echo "::add-matcher::$PWD/coq.json"
+
 ## Note to docker-coq-action maintainers: Run ./helper.sh gen & Copy min.sh
 docker run -i --init --rm --name=COQ -e WORKDIR="$WORKDIR" -e PACKAGE="$PACKAGE" \
        -v "$HOST_WORKSPACE_REPO:$PWD" -w "$PWD" \
@@ -149,3 +153,5 @@ endGroup () {  {  init_opts=\"\$-\"; set +x ; } 2> /dev/null; if [ -n \"\$startT
 export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '; set -ex
 $_OCAML407_COMMAND
 $INPUT_CUSTOM_SCRIPT" script
+
+echo "::remove-matcher owner=coq-problem-matcher::"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -142,8 +142,8 @@ else
     _OCAML407_COMMAND=''
 fi
 
-cp /app/coq.json ./coq.json
-echo "::add-matcher::$PWD/coq.json"
+cp /app/coq.json "$HOME/coq.json"
+echo "::add-matcher::$HOME/coq.json"
 
 ## Note to docker-coq-action maintainers: Run ./helper.sh gen & Copy min.sh
 docker run -i --init --rm --name=COQ -e WORKDIR="$WORKDIR" -e PACKAGE="$PACKAGE" \


### PR DESCRIPTION
Thanks to @JasonGross for suggesting this feature!

I had to slightly change the regexp's to cope with the `- ` prefix that `opam install` adds in verbose mode, (and I disabled the verbose mode for dependencies in the standard build script (relying on opam's `--deps-only` argument)).

URL of the accompanying demo:
https://github.com/erikmd/docker-coq-github-action-demo/actions/runs/88432565