### PR TITLE
fix: Remove OCAML patch-level in "$COQ-ocaml-$OCAML-flambda" tags

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -121,7 +121,7 @@ fi
 # todo: update this after the one-switch docker-coq migration
 OCAML407="false"
 if [ "$INPUT_OCAML_VERSION" = '4.09-flambda' ]; then
-    COQ_IMAGE="${COQ_IMAGE}-ocaml-4.09.0-flambda"
+    COQ_IMAGE="${COQ_IMAGE}-ocaml-4.09-flambda"
 elif [ "$INPUT_OCAML_VERSION" = '4.07-flambda' ]; then
     OCAML407="true"
 # else Assume "$INPUT_OCAML_VERSION" = 'minimal'


### PR DESCRIPTION
for more consistency (to have the same granularity for both $COQ and $OCAML versions), the `coqorg/coq:*-4.09*` images have been renamed (and 4.09.0+flambda is replaced with **4.09.1+flambda**)

cf. the (now automatically generated) README of the `coqorg/coq` repo:
https://hub.docker.com/r/coqorg/coq