### PR TITLE
feat: Make opam_file optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,18 +72,25 @@ See also the [example repo](https://github.com/erikmd/docker-coq-github-action-d
 
 #### `opam_file`
 
-**Required** the path of the `.opam` file, relative to the repo root.
+*Optional* the path of the `.opam` file (or a directory), relative to the repo root.
+Default `"."` (if the argument is omitted or an empty string).
 
-*Note:* relying on the value of this `INPUT_OPAM_FILE` variable, the
+*Note-1:* relying on the value of this `INPUT_OPAM_FILE` variable, the
 following two variables are exported when running the `custom_script`:
 
 ```bash
-WORKDIR=$(dirname "$INPUT_OPAM_FILE")
-PACKAGE=$(basename "$INPUT_OPAM_FILE" .opam)
+if [ -z "$INPUT_OPAM_FILE" ] || [ -d "$INPUT_OPAM_FILE" ]; then
+    WORKDIR=""
+    PACKAGE=${INPUT_OPAM_FILE:-.}
+else
+    WORKDIR=$(dirname "$INPUT_OPAM_FILE")
+    PACKAGE=$(basename "$INPUT_OPAM_FILE" .opam)
+fi
 ```
 
-See also the
-[`custom_script` default value](#custom_script).
+*Note-2:* if this value is a directory (e.g., `.`), relying on the
+[`custom_script` default value](#custom_script), the action will
+install all the `*.opam` packages stored in this directory.
 
 #### `coq_version`
 

--- a/action.yml
+++ b/action.yml
@@ -6,8 +6,8 @@ description: 'GitHub Action using Docker-Coq'
 author: 'Erik Martin-Dorel'
 inputs:
   opam_file:
-    description: 'The path of the .opam file, relative to the repo root.'
-    required: true
+    description: 'The path of the .opam file (or a directory), relative to the repo root.'
+    default: '.'
   coq_version:
     description: '"8.X", "latest", or "dev".'
     default: 'latest'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,8 +7,13 @@ timegroup_file="/app/timegroup.sh"
 # shellcheck source=./timegroup.sh
 . "$timegroup_file"
 
-WORKDIR=$(dirname "$INPUT_OPAM_FILE")
-PACKAGE=$(basename "$INPUT_OPAM_FILE" .opam)
+if [ -z "$INPUT_OPAM_FILE" ] || [ -d "$INPUT_OPAM_FILE" ]; then
+    WORKDIR=""
+    PACKAGE=${INPUT_OPAM_FILE:-.}
+else
+    WORKDIR=$(dirname "$INPUT_OPAM_FILE")
+    PACKAGE=$(basename "$INPUT_OPAM_FILE" .opam)
+fi
 
 startGroup Print runner configuration
 
@@ -52,7 +57,7 @@ Usage:
   $0
 
 Options:
-INPUT_OPAM_FILE: the path of the .opam file, relative to the repo root
+INPUT_OPAM_FILE: the path of the .opam file (or a directory), relative to the repo root
 INPUT_COQ_VERSION: the version of Coq (without patch-level)
 INPUT_OCAML_VERSION: the version of OCaml (minimal, 4.07-flambda, 4.09-flambda)
 INPUT_CUSTOM_SCRIPT: the main script run in the container
@@ -79,19 +84,6 @@ shift "$((OPTIND-1))" # Shift off the options and optional "--".
 if test $# -gt 0; then
     echo "Warning: Arguments ignored: $*"
 fi
-
-if test -z "$INPUT_OPAM_FILE"; then
-    echo "ERROR: No opam_file specified."
-    usage
-    exit 1
-fi
-
-case "$INPUT_OPAM_FILE" in
-    *.opam)
-        :;;
-    *)
-        echo "Warning: the opam_file argument should have the '.opam' suffix.";;
-esac
 
 if test -z "$INPUT_CUSTOM_IMAGE"; then
     if test -z "$INPUT_COQ_VERSION"; then


### PR DESCRIPTION
* Make opam_file optional

* This also enables the following feature: compiling a Coq project containing several `*.opam` files in one go.

Close #26

@JasonGross do you think you could test this PR before we merge it?

I mean, by using the `docker-coq-action@optional-opam-file` reference in some of your GHA workflow, e.g.:

```yaml
jobs:
  example:
    runs-on: ubuntu-latest
    steps:
      - name: Check out the repo
        uses: actions/checkout@v2
      - name: Run docker-coq-action
        uses: coq-community/docker-coq-action@optional-opam-file
        with:
          custom_image: 'registry.gitlab.com/coq/coq:bionic_coq-V2020-08-28-V92'
          custom_script: |
            startGroup Example
              echo ${{ github.ref }}
            endGroup
            startGroup Install APT dependencies
              sudo apt-get update -y -q
              sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -q libgmp-dev  # for example
            endGroup Run test
              ./run.sh
            endGroup
```