### PR TITLE
Add feature to export env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,39 @@ steps:
       custom_image: ${{ matrix.image }}
 ```
 
+#### `export`
+
+*Optional* A space-separated list of `env` variables to export to the `custom_script`.
+
+*Note-1:* The values of the variables to export may be defined by using the
+[`env`](https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables)
+keyword.
+
+*Note-2:* Regarding the naming of these variables:
+
+* Only use ASCII letters, `_` and digits, i.e., matching the `[a-zA-Z_][a-zA-Z0-9_]*` regexp.
+* Avoid [reserved identifiers](https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables) (namely: `HOME`, `CI`, and strings starting with `GITHUB_`, `ACTIONS_`, `RUNNER_`, or `INPUT_`).
+
+Here is a minimal working example of this feature:
+
+```yaml
+runs-on: ubuntu-latest
+steps:
+  - uses: coq-community/docker-coq-action@v1
+    with:
+      custom_script: |
+        printf "%s\n" "$first_example"
+        startGroup Build dependencies, with-test
+          opam pin add -n -y -k path $PACKAGE $WORKDIR
+          opam update -y
+          opam install -y -j 2 $PACKAGE --deps-only
+        endGroup
+      export: 'first_example OPAMWITHTEST'
+    env:
+      first_example: 'some value'
+      OPAMWITHTEST: 'true'
+```
+
 ### Remarks
 
 The `docker-coq-action` provides built-in support for `opam` builds.

--- a/README.md
+++ b/README.md
@@ -224,20 +224,21 @@ Here is a minimal working example of this feature:
 ```yaml
 runs-on: ubuntu-latest
 steps:
+  - uses: actions/checkout@v2
   - uses: coq-community/docker-coq-action@v1
     with:
-      custom_script: |
-        printf "%s\n" "$first_example"
-        startGroup Build dependencies, with-test
-          opam pin add -n -y -k path $PACKAGE $WORKDIR
-          opam update -y
-          opam install -y -j 2 $PACKAGE --deps-only
-        endGroup
-      export: 'first_example OPAMWITHTEST'
+      opam_file: 'folder/coq-proj.opam'
+      coq_version: 'dev'
+      ocaml_version: '4.07-flambda'
+      export: 'OPAMWITHTEST'  # space-separated list of variables
     env:
-      first_example: 'some value'
       OPAMWITHTEST: 'true'
 ```
+
+Here, setting the [`OPAMWITHTEST`](https://opam.ocaml.org/doc/man/opam-install.html#lbAG)
+environment variable is useful to run the unit tests
+(specified using `opam`'s [`with-test`](http://opam.ocaml.org/doc/Manual.html#pkgvar-with-test)
+clause) after the package build.
 
 ### Remarks
 

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,8 @@ inputs:
       endGroup
   custom_image:
     description: 'The name of the Docker image to pull; unset by default.'
+  export:
+    description: 'Space-separated list of env variables to export to the custom_script.'
 runs:
   using: 'docker'
   image: 'Dockerfile'


### PR DESCRIPTION
- **Kind:** feature
- Close #23 (this feature being requested by @liyishuai)
- **Depends-on: #32 (to be merged before #31)**

FYI I've done a system test, relying on Yishuai's suggestion to pass `OPAMWITHTEST`:
- https://github.com/erikmd/docker-coq-github-action-demo/blob/337ecf043c94303b720062069f99d8a8d4e52555/.github/workflows/build-coq-demo.yml#L39-L54

and it seems to work pretty well:
~- https://github.com/erikmd/docker-coq-github-action-demo/runs/1456333460?check_suite_focus=true~ [see [comment below](https://github.com/coq-community/docker-coq-action/pull/31#issuecomment-734007307)]

As an aside, I didn't implement that other suggestion for the moment:
- https://github.com/coq-community/docker-coq-action/issues/23#issuecomment-657271610

but it could just as well be passed using the feature of this PR #31 (unless we decide to hard-code `OPAMYES` anyway!)

Maybe this can be merged on tomorrow Thursday, after #30 and #32, as soon as one of you (@Zimmi48, @liyishuai) took a look.