### PR TITLE
Move startGroup/endGroup constructs to individual fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,23 @@ clause) after the package build.
 
 ### Remarks
 
+#### startGroup/endGroup
+
+The default value of fields `{{before_install}}`, `{{install}}`,
+`{{after_install}}`, `{{script}}`, and `{{uninstall}}` involves the
+functions `startGroup` (taking 1 argument: `startGroup "Group title"`)
+and `endGroup`.
+
+These bash functions have the following features:
+
+* they create foldable groups in the GitHub Actions logs
+    (see the [online doc](https://github.com/actions/toolkit/blob/master/docs/commands.md#group-and-ungroup-log-lines)),
+* and they compute the elapsed time for the considered group;
+* these groups cannot be nested,
+* and if an `endGroup` has been forgotten, it is implicitly and
+  automatically inserted at the next `startGroup` (albeit it is better
+  to make each `endGroup` explicit, for readability).
+
 #### Permissions
 
 If you use the

--- a/README.md
+++ b/README.md
@@ -111,7 +111,9 @@ Among `"minimal"`, `"4.07-flambda"`, `"4.09-flambda"`.
 Default:
 
 ```
-opam config list; opam repo list; opam list
+startGroup Print opam config
+  opam config list; opam repo list; opam list
+endGroup
 ```
 
 See [`custom_script`](#custom_script) for more details.
@@ -123,9 +125,11 @@ See [`custom_script`](#custom_script) for more details.
 Default:
 
 ```
-opam pin add -n -y -k path $PACKAGE $WORKDIR
-opam update -y
-opam install -y -j 2 $PACKAGE --deps-only
+startGroup Install dependencies
+  opam pin add -n -y -k path $PACKAGE $WORKDIR
+  opam update -y
+  opam install -y -j 2 $PACKAGE --deps-only
+endGroup
 ```
 
 See [`custom_script`](#custom_script) for more details.
@@ -137,7 +141,9 @@ See [`custom_script`](#custom_script) for more details.
 Default:
 
 ```
-opam list
+startGroup List installed packages
+  opam list
+endGroup
 ```
 
 See [`custom_script`](#custom_script) for more details.
@@ -155,8 +161,10 @@ See [`custom_script`](#custom_script) for more details.
 Default:
 
 ```
-opam install -y -v -j 2 $PACKAGE
-opam list
+startGroup Build
+  opam install -y -v -j 2 $PACKAGE
+  opam list
+endGroup
 ```
 
 See [`custom_script`](#custom_script) for more details.
@@ -174,7 +182,9 @@ See [`custom_script`](#custom_script) for more details.
 Default:
 
 ```
-opam remove $PACKAGE
+startGroup Uninstallation test
+  opam remove $PACKAGE
+endGroup
 ```
 
 See [`custom_script`](#custom_script) for more details.
@@ -186,27 +196,13 @@ See [`custom_script`](#custom_script) for more details.
 Default:
 
 ```
-startGroup before_install dependencies
-  {{before_install}}
-endGroup
-startGroup install dependencies
-  {{install}}
-endGroup
-startGroup after_install dependencies
-  {{after_install}}
-endGroup
-startGroup before_script
-  {{before_script}}
-endGroup
-startGroup script
-  {{script}}
-endGroup
-startGroup after_script
-  {{after_script}}
-endGroup
-startGroup uninstall
-  {{uninstall}}
-endGroup
+{{before_install}}
+{{install}}
+{{after_install}}
+{{before_script}}
+{{script}}
+{{after_script}}
+{{uninstall}}
 ```
 
 *Note-1:* the semantics of this variable is a *standard Bash script*,
@@ -322,12 +318,17 @@ steps:
       opam_file: 'coq-demo.opam'
       custom_image: ${{ matrix.image }}
       before_script: |
-        echo Workaround permission issue
-        sudo chown -R coq:coq .    # <--
+        startGroup Workaround permission issue
+          sudo chown -R coq:coq .  # <--
+        endGroup
       script: |
-        make -j2
+        startGroup Build project
+          make -j2
+        endGroup
       uninstall: |
-        make clean
+        startGroup Clean project
+          make clean
+        endGroup
   - name: Revert permissions
     # to avoid a warning at cleanup time
     if: ${{ always() }}

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Among `"minimal"`, `"4.07-flambda"`, `"4.09-flambda"`.
 Default:
 
 ```
-startGroup Print opam config
+startGroup "Print opam config"
   opam config list; opam repo list; opam list
 endGroup
 ```
@@ -125,7 +125,7 @@ See [`custom_script`](#custom_script) for more details.
 Default:
 
 ```
-startGroup Install dependencies
+startGroup "Install dependencies"
   opam pin add -n -y -k path $PACKAGE $WORKDIR
   opam update -y
   opam install -y -j 2 $PACKAGE --deps-only
@@ -141,7 +141,7 @@ See [`custom_script`](#custom_script) for more details.
 Default:
 
 ```
-startGroup List installed packages
+startGroup "List installed packages"
   opam list
 endGroup
 ```
@@ -161,7 +161,7 @@ See [`custom_script`](#custom_script) for more details.
 Default:
 
 ```
-startGroup Build
+startGroup "Build"
   opam install -y -v -j 2 $PACKAGE
   opam list
 endGroup
@@ -182,7 +182,7 @@ See [`custom_script`](#custom_script) for more details.
 Default:
 
 ```
-startGroup Uninstallation test
+startGroup "Uninstallation test"
   opam remove $PACKAGE
 endGroup
 ```
@@ -335,15 +335,15 @@ steps:
       opam_file: 'coq-demo.opam'
       custom_image: ${{ matrix.image }}
       before_script: |
-        startGroup Workaround permission issue
+        startGroup "Workaround permission issue"
           sudo chown -R coq:coq .  # <--
         endGroup
       script: |
-        startGroup Build project
+        startGroup "Build project"
           make -j2
         endGroup
       uninstall: |
-        startGroup Clean project
+        startGroup "Clean project"
           make clean
         endGroup
   - name: Revert permissions

--- a/action.yml
+++ b/action.yml
@@ -17,54 +17,50 @@ inputs:
   before_install:
     description: 'Customizable script run before "install", empty by default.'
     default: |
-      opam config list; opam repo list; opam list
+      startGroup Print opam config
+        opam config list; opam repo list; opam list
+      endGroup
   install:
     description: 'Customizable script to install the opam dependencies.'
     default: |
-      opam pin add -n -y -k path $PACKAGE $WORKDIR
-      opam update -y
-      opam install -y -j 2 $PACKAGE --deps-only
+      startGroup Install dependencies
+        opam pin add -n -y -k path $PACKAGE $WORKDIR
+        opam update -y
+        opam install -y -j 2 $PACKAGE --deps-only
+      endGroup
   after_install:
     description: 'Customizable script run after "install".'
     default: |
-      opam list
+      startGroup List installed packages
+        opam list
+      endGroup
   before_script:
     description: 'Customizable script run before the opam build, empty by default.'        
   script:
     description: 'Customizable script run to install the opam package(s).'
     default: |
-      opam install -y -v -j 2 $PACKAGE
-      opam list  
+      startGroup Build
+        opam install -y -v -j 2 $PACKAGE
+        opam list
+      endGroup
   after_script:
     description: 'Customizable script run after the opam build, empty by default.'
   uninstall:
     description: 'Customizable script run to uninstall the opam package(s).'
     default: |
-      opam remove $PACKAGE
+      startGroup Installation test
+        opam remove $PACKAGE
+      endGroup
   custom_script:
     description: 'The main script run in the container; may be overridden.'
     default: |
-      startGroup before_install dependencies
-        {{before_install}}
-      endGroup
-      startGroup install dependencies
-        {{install}}
-      endGroup
-      startGroup after_install dependencies
-        {{after_install}}
-      endGroup
-      startGroup before_script
-        {{before_script}}
-      endGroup
-      startGroup script
-        {{script}}
-      endGroup
-      startGroup after_script
-        {{after_script}}
-      endGroup
-      startGroup uninstall
-        {{uninstall}}
-      endGroup
+      {{before_install}}
+      {{install}}
+      {{after_install}}
+      {{before_script}}
+      {{script}}
+      {{after_script}}
+      {{uninstall}}
   custom_image:
     description: 'The name of the Docker image to pull; unset by default.'
   export:

--- a/action.yml
+++ b/action.yml
@@ -17,13 +17,13 @@ inputs:
   before_install:
     description: 'Customizable script run before "install", empty by default.'
     default: |
-      startGroup Print opam config
+      startGroup "Print opam config"
         opam config list; opam repo list; opam list
       endGroup
   install:
     description: 'Customizable script to install the opam dependencies.'
     default: |
-      startGroup Install dependencies
+      startGroup "Install dependencies"
         opam pin add -n -y -k path $PACKAGE $WORKDIR
         opam update -y
         opam install -y -j 2 $PACKAGE --deps-only
@@ -31,7 +31,7 @@ inputs:
   after_install:
     description: 'Customizable script run after "install".'
     default: |
-      startGroup List installed packages
+      startGroup "List installed packages"
         opam list
       endGroup
   before_script:
@@ -39,7 +39,7 @@ inputs:
   script:
     description: 'Customizable script run to install the opam package(s).'
     default: |
-      startGroup Build
+      startGroup "Build"
         opam install -y -v -j 2 $PACKAGE
         opam list
       endGroup
@@ -48,7 +48,7 @@ inputs:
   uninstall:
     description: 'Customizable script run to uninstall the opam package(s).'
     default: |
-      startGroup Installation test
+      startGroup "Installation test"
         opam remove $PACKAGE
       endGroup
   custom_script:


### PR DESCRIPTION
* **Kind:** fix
* Closes #34

Impact:
* this slightly changes defaults values w.r.t. v1.2.0
* but this is fully backward-compatible w.r.t. v1.1.0
* and this makes it possible to customize group names (that cannot be nested)

I can readily do a point release if you want @tchajed ; otherwise tomorrow Saturday :)