### PR TITLE
fix: Adapt to PR coq-community/docker-coq#47

### DIFF
--- a/.github/workflows/coq-demo.yml
+++ b/.github/workflows/coq-demo.yml
@@ -25,9 +25,10 @@ jobs:
         # To get the list of supported (coq, ocaml) versions from coqorg/coq,
         # see https://github.com/coq-community/docker-coq/wiki#supported-tags
         coq_version:
-          - 'latest'
+          - '8.16'
+          - 'latest-native'
           - 'dev'
-        ocaml_version: ['4.07-flambda']
+        ocaml_version: ['default']
       fail-fast: false  # don't stop jobs if one fails
     steps:
       ################################################################

--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ runs-on: ubuntu-latest  # container actions require GNU/Linux
 strategy:
   matrix:
     coq_version:
-      - '8.11'
+      - '8.16'
       - dev
-    ocaml_version: ['4.07-flambda']
+    ocaml_version: ['default']
   fail-fast: false  # don't stop jobs if one fails
 steps:
   - uses: actions/checkout@v2
@@ -181,7 +181,11 @@ Default: `"latest"` (= latest stable version).
 Append the `-native` suffix if the version is `>= 8.13` (or `dev`)
 *and* you are interested in the image that contains the
 [`coq-native`](https://opam.ocaml.org/packages/coq-native/) package.
-E.g., `"dev-native"`. In this case, the `ocaml_version` must be `"4.07"`.
+E.g., `"8.13-native"`, `"latest-native"`, `"dev-native"`.
+
+If the `coq_version` value contains the `-native` suffix,
+the `ocaml_version` value is ignored (as `coq-native` images only come with a single OCaml version).
+Still, a warning is raised if `ocaml_version` is nonempty and different from `"default"`.
 
 #### `ocaml_version`
 
@@ -189,14 +193,15 @@ E.g., `"dev-native"`. In this case, the `ocaml_version` must be `"4.07"`.
 
 The version of OCaml.
 
-Default: `"minimal"`.
+Default: `"default"` (= Docker-Coq's default OCaml version for the given Coq version).
 
-Among `"minimal"`, `"4.07-flambda"`, `"4.07"`, `"4.08-flambda"`,
-`"4.09-flambda"`, `"4.10-flambda"`, `"4.11-flambda"`, `"4.12-flambda"`.
+Among `"minimal"` (*deprecated, to be removed after 27 June 2022 AOE*),
+`"default"`, `"4.02"`, `"4.05"`, `"4.07-flambda"`, `"4.08-flambda"`, `"4.09-flambda"`, `"4.10-flambda"`, `"4.11-flambda"`, `"4.12-flambda"`, `"4.13-flambda"`, `"4.14-flambda"`…
 
 **Warning!** not all OCaml versions are available with all Coq versions.
 
-For details, see: <https://github.com/coq-community/docker-coq/wiki#supported-tags>
+The supported compilers w.r.t. each version of Coq are documented in the
+[OCaml-versions policy](https://github.com/coq-community/docker-coq/wiki#ocaml-versions-policy) section of the `docker-coq` wiki.
 
 #### `before_install`
 
@@ -408,7 +413,7 @@ steps:
     with:
       opam_file: 'folder/coq-proj.opam'
       coq_version: 'dev'
-      ocaml_version: '4.07-flambda'
+      ocaml_version: 'default'
       export: 'OPAMWITHTEST'  # space-separated list of variables
     env:
       OPAMWITHTEST: 'true'

--- a/action.yml
+++ b/action.yml
@@ -9,11 +9,11 @@ inputs:
     description: 'The path of the .opam file (or a directory), relative to the repo root.'
     default: '.'
   coq_version:
-    description: '"8.X", "latest", or "dev".'
+    description: '"8.X", "latest", "dev", "8.X-native", "latest-native", or "dev-native"'
     default: 'latest'
   ocaml_version:
-    description: '"minimal", "4.XX", or "4.XX-flambda", see https://github.com/coq-community/docker-coq/wiki#supported-tags'
-    default: 'minimal'
+    description: '"minimal" (deprecated), "default", "4.02", "4.05", or "4.XX-flambda", see https://github.com/coq-community/docker-coq/wiki#ocaml-versions-policy'
+    default: 'default'
   before_install:
     description: 'Customizable script run before "install".'
     default: |


### PR DESCRIPTION
~~Can be merged and released after https://github.com/coq-community/docker-coq/pull/7 is deployed~~

~~This is a backward-compatible migration, so if there were no new release of the action, `coq-community/docker-coq-action@v1.2.2` will continue to work as is with existing configurations until December 14, since Docker-Coq's "default tags" (which don't specify an ocaml version) will be retained as dual-switch up to December 14.~~

**Edit:** Adapt to https://github.com/coq-community/docker-coq/pull/47