### PR TITLE
fix: interpolated scripts couldn't contain single-quotes

### DIFF
--- a/.github/workflows/gha-rt.yml
+++ b/.github/workflows/gha-rt.yml
@@ -1,0 +1,31 @@
+name: Regression Test
+on:
+  push:
+    branches:
+      - master  # forall push/merge in master
+  pull_request:
+    branches:
+      - "**"  # forall submitted Pull Requests
+jobs:
+
+  issue-40:
+    # interpolated scripts couldn't contain single-quotes
+    runs-on: ubuntu-latest
+    steps:
+      # BEGIN GHA_TEST_ENV
+      - uses: actions/checkout@v2
+        with:
+          repository: 'erikmd/docker-coq-github-action-demo'
+          ref: 'master'
+      - uses: actions/checkout@v2
+        with:
+          path: 'docker-coq-action'
+      - uses: './docker-coq-action'
+        # END GHA_TEST_ENV
+        with:
+          opam_file: 'coq-demo.opam'
+          custom_image: 'coqorg/coq:8.13'
+          before_script: |
+            opam repo list
+            opam repo add --all-switches --set-default coq-extra-dev 'https://coq.inria.fr/opam/extra-dev'
+            opam repo list

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -138,9 +138,9 @@ startGroup "Install perl for mustache interpolation"
 apk add --no-cache perl
 
 moperl() {
-    mo="$1"
-    value="$2"
-    perl -wpe 'BEGIN {$dest = '\'"$value"\'';}; s/\{\{'"$mo"'\}\}/$dest/g;'
+    re="$1"  # pattern to replace, without the surrounding {{ }}'s
+    str="$2"
+    perl -wpe 'BEGIN {$re=shift @ARGV; $str=shift @ARGV;}; s/\{\{$re\}\}/$str/g;' "$re" "$str"
 }
 
 INPUT_CUSTOM_SCRIPT_EXPANDED=$(printf "%s" "$INPUT_CUSTOM_SCRIPT" | \


### PR DESCRIPTION
* Kind: bugfix
* Close #40 (Cc @gares FYI)

Summary:

* Improve the `moperl` function (no need for the previous bash quoting hack)

@Zimmi48 I only did manual unit tests for now :) so I'll merge this and make a point release very soon, after I've done an e2e test.