### PR TITLE
Update the list of possible values for ocaml_version in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,10 +99,18 @@ install all the `*.opam` packages stored in this directory.
 *Optional* The version of Coq. E.g., `"8.10"`. Default
 `"latest"` (= latest stable version).
 
+Append the `-native` suffix if the version is `>= 8.13` (or `dev`)
+*and* you are interested in the image that contains the
+[`coq-native`](http://opam.ocaml.org/packages/coq-native/) package.
+E.g., `dev-native`. In this case, the `ocaml_version` must be `4.07`.
+
 #### `ocaml_version`
 
 *Optional* The version of OCaml. Default `"minimal"`.
-Among `"minimal"`, `"4.07-flambda"`, `"4.09-flambda"`.
+Among `"minimal"`, `"4.07-flambda"`, `"4.07"`, ``"4.08-flambda"`,
+`"4.09-flambda"`, `"4.10-flambda"`, `"4.11-flambda"`.
+
+For details, see: <https://github.com/coq-community/docker-coq/wiki#supported-tags>
 
 #### `before_install`
 


### PR DESCRIPTION
Kind: this is a documentation-only PR.

@Zimmi48 could you have a look at this PR and merge it if you approve it? (or directly modify the branch if need be!)

indeed given https://github.com/coq-community/docker-coq/issues/23, it appears it'd be good to document the current state of supported `ocaml_version`s from Docker-Coq in the master README (in the same way as I had documented the on-going change in the docker-coq wiki) and this, even if #39 which will bring yet more documentation, is not yet ready.