### PR TITLE
[build] pass --with-test for the current package

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,7 @@ inputs:
     description: 'Customizable script run to install the opam package(s).'
     default: |
       startGroup "Build"
-        opam install -y -v -j 2 $PACKAGE
+        opam install -y -v -j 2 --with-test $PACKAGE
         opam list
       endGroup
   after_script:


### PR DESCRIPTION
It is customary in OPAM packages to separate build instruction from testing instructions.
The latter are only run if `--with-test` is passed.