### PR TITLE
meta-ci: Add an automated test-suite for `docker-coq-action@$GITHUB_SHA`

### DIFF
--- a/.github/workflows/coq-demo.yml
+++ b/.github/workflows/coq-demo.yml
@@ -102,11 +102,15 @@ jobs:
             endGroup
           script: |
             startGroup "Build project"
+              coq_makefile -f _CoqProject -o Makefile
               make -j2
+              make test
+              make install
             endGroup
           uninstall: |
             startGroup "Clean project"
               make clean
+              make uninstall
             endGroup
       - name: Revert permissions
         # to avoid a warning at cleanup time
@@ -152,10 +156,14 @@ jobs:
               sudo chown -R coq:coq .
             endGroup
             startGroup "Build project"
+              coq_makefile -f _CoqProject -o Makefile
               make -j2
+              make test
+              make install
             endGroup
             startGroup "Clean project"
               make clean
+              make uninstall
             endGroup
       - name: Revert permissions
         # to avoid a warning at cleanup time

--- a/.github/workflows/coq-demo.yml
+++ b/.github/workflows/coq-demo.yml
@@ -1,0 +1,195 @@
+name: Docker-Coq CI
+on:
+  push:
+    branches:
+      - master  # forall push/merge in master
+      - v1      # forall push/merge in v1
+  pull_request:
+    branches:
+      - "**"  # forall submitted Pull Requests
+jobs:
+
+  setup-coq-demo:
+    name: checkout / coq-demo
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: 'erikmd/docker-coq-github-actions-demo'
+          ref: 'master'
+
+  # The following two jobs are standard/recommended versions, assuming
+  # your coq project repository contains a committed .opam file.
+
+  demo-1:
+    name: coq_version / docker-coq / opam
+    needs: setup-coq-demo
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # To get the list of supported (coq, ocaml) versions from coqorg/coq,
+        # see https://github.com/coq-community/docker-coq/wiki#supported-tags
+        coq_version:
+          - '8.13'
+          - 'dev'
+        ocaml_version: ['4.07-flambda']
+      fail-fast: false  # don't stop jobs if one fails
+    steps:
+      - uses: coq-community/docker-coq-action@${{ github.sha }}
+        with:
+          opam_file: 'coq-demo.opam'
+          coq_version: ${{ matrix.coq_version }}
+          ocaml_version: ${{ matrix.ocaml_version }}
+
+  demo-2:
+    name: custom_image / docker-mathcomp / opam
+    needs: setup-coq-demo
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image:
+          - 'mathcomp/mathcomp-dev:coq-dev'
+          # - 'mathcomp/mathcomp:latest-coq-dev'  # not always available,
+          # see https://hub.docker.com/r/mathcomp/mathcomp#supported-tags
+      fail-fast: false  # don't stop jobs if one fails
+    steps:
+      - uses: coq-community/docker-coq-action@${{ github.sha }}
+        with:
+          opam_file: 'coq-demo.opam'
+          custom_image: ${{ matrix.image }}
+
+  # The following job illustrates the use of several customizable fields,
+  # while keeping the default value of the overall "custom_script" field,
+  # see https://github.com/coq-community/docker-coq-action#custom_script
+
+  demo-3:
+    name: custom_image / docker-coq / make / script
+    needs: setup-coq-demo
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image:
+          - 'coqorg/coq:8.13'
+      fail-fast: false  # don't stop jobs if one fails
+    steps:
+      - uses: coq-community/docker-coq-action@${{ github.sha }}
+        with:
+          # As the install/script/uninstall fields are overridden,
+          # the "opam_file" field is unneeded in this example job.
+          custom_image: ${{ matrix.image }}
+          install: |
+            startGroup "Install dependencies"
+              opam install -y -j 2 coq-mathcomp-ssreflect
+            endGroup
+          before_script: |
+            startGroup "Workaround permission issue"
+              sudo chown -R coq:coq .
+            endGroup
+          script: |
+            startGroup "Build project"
+              make -j2
+            endGroup
+          uninstall: |
+            startGroup "Clean project"
+              make clean
+            endGroup
+      - name: Revert permissions
+        # to avoid a warning at cleanup time
+        if: ${{ always() }}
+        run: sudo chown -R 1001:116 .
+
+  # The following job illustrates the redefinition of the
+  # "custom_script" field.
+  
+  demo-4:
+    name: custom_image / docker-coq / make / custom_script
+    needs: setup-coq-demo
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image:
+          - 'coqorg/coq:8.13'
+      fail-fast: false  # don't stop jobs if one fails
+    steps:
+      - uses: coq-community/docker-coq-action@${{ github.sha }}
+        with:
+          custom_image: ${{ matrix.image }}
+          custom_script: |
+            startGroup "Print opam config"
+              opam config list; opam repo list; opam list
+            endGroup
+            startGroup "Install dependencies"
+              opam update -y
+              opam install -y -j 2 coq-mathcomp-ssreflect
+            endGroup
+            startGroup "List installed packages"
+              opam list
+            endGroup
+            startGroup "Workaround permission issue"
+              sudo chown -R coq:coq .
+            endGroup
+            startGroup "Build project"
+              make -j2
+            endGroup
+            startGroup "Clean project"
+              make clean
+            endGroup
+      - name: Revert permissions
+        # to avoid a warning at cleanup time
+        if: ${{ always() }}
+        run: sudo chown -R 1001:116 .
+
+  # The following job illustrates how to pass environment variables.
+
+  demo-5:
+    name: custom_image / docker-coq / opam / env
+    needs: setup-coq-demo
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image:
+          - 'coqorg/coq:8.13'
+      fail-fast: false  # don't stop jobs if one fails
+    steps:
+      - uses: coq-community/docker-coq-action@${{ github.sha }}
+        with:
+          opam_file: 'coq-demo.opam'
+          custom_image: ${{ matrix.image }}
+          before_script: |
+            startGroup "Toy example"
+              echo "ex_var=$ex_var"
+            endGroup
+          export: 'ex_var OPAMWITHTEST'  # space-separated list of variables
+        env:
+          OPAMWITHTEST: 'true'
+          ex_var: 'ex_value'
+
+  # The following job illustrates the installation of additional Debian packages.
+
+  demo-6:
+    name: custom_image / docker-coq / apt-get
+    needs: setup-coq-demo
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image:
+          - 'coqorg/coq:8.13'
+      fail-fast: false  # don't stop jobs if one fails
+    steps:
+      - uses: coq-community/docker-coq-action@${{ github.sha }}
+        with:
+          opam_file: 'coq-demo.opam'
+          custom_image: ${{ matrix.image }}
+          before_script: |
+            startGroup "Install APT dependencies"
+              cat /etc/os-release
+              sudo apt-get update -y -q
+              sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -q --no-install-recommends \
+                emacs \
+                tree  # for instance (in alphabetical order)
+            endGroup
+          after_script: |
+            startGroup "Post-test"
+              emacs --version
+              tree
+            endGroup

--- a/.github/workflows/coq-demo.yml
+++ b/.github/workflows/coq-demo.yml
@@ -9,21 +9,11 @@ on:
       - "**"  # forall submitted Pull Requests
 jobs:
 
-  setup-coq-demo:
-    name: checkout / coq-demo
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          repository: 'erikmd/docker-coq-github-actions-demo'
-          ref: 'master'
-
   # The following two jobs are standard/recommended versions, assuming
   # your coq project repository contains a committed .opam file.
 
   demo-1:
     name: coq_version / docker-coq / opam
-    needs: setup-coq-demo
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -35,7 +25,16 @@ jobs:
         ocaml_version: ['4.07-flambda']
       fail-fast: false  # don't stop jobs if one fails
     steps:
-      - uses: coq-community/docker-coq-action@${{ github.sha }}
+      - &setup-coq-demo
+        uses: actions/checkout@v2
+        with:
+          repository: 'erikmd/docker-coq-github-action-demo'
+          ref: 'master'
+      - &setup-docker-coq-action
+        uses: actions/checkout@v2
+        with:
+          path: 'docker-coq-action'
+      - uses: './docker-coq-action'
         with:
           opam_file: 'coq-demo.opam'
           coq_version: ${{ matrix.coq_version }}
@@ -43,7 +42,6 @@ jobs:
 
   demo-2:
     name: custom_image / docker-mathcomp / opam
-    needs: setup-coq-demo
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -53,7 +51,9 @@ jobs:
           # see https://hub.docker.com/r/mathcomp/mathcomp#supported-tags
       fail-fast: false  # don't stop jobs if one fails
     steps:
-      - uses: coq-community/docker-coq-action@${{ github.sha }}
+      - *setup-coq-demo
+      - *setup-docker-coq-action
+      - uses: './docker-coq-action'
         with:
           opam_file: 'coq-demo.opam'
           custom_image: ${{ matrix.image }}
@@ -64,7 +64,6 @@ jobs:
 
   demo-3:
     name: custom_image / docker-coq / make / script
-    needs: setup-coq-demo
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -72,7 +71,9 @@ jobs:
           - 'coqorg/coq:8.13'
       fail-fast: false  # don't stop jobs if one fails
     steps:
-      - uses: coq-community/docker-coq-action@${{ github.sha }}
+      - *setup-coq-demo
+      - *setup-docker-coq-action
+      - uses: './docker-coq-action'
         with:
           # As the install/script/uninstall fields are overridden,
           # the "opam_file" field is unneeded in this example job.
@@ -103,7 +104,6 @@ jobs:
   
   demo-4:
     name: custom_image / docker-coq / make / custom_script
-    needs: setup-coq-demo
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -111,7 +111,9 @@ jobs:
           - 'coqorg/coq:8.13'
       fail-fast: false  # don't stop jobs if one fails
     steps:
-      - uses: coq-community/docker-coq-action@${{ github.sha }}
+      - *setup-coq-demo
+      - *setup-docker-coq-action
+      - uses: './docker-coq-action'
         with:
           custom_image: ${{ matrix.image }}
           custom_script: |
@@ -143,7 +145,6 @@ jobs:
 
   demo-5:
     name: custom_image / docker-coq / opam / env
-    needs: setup-coq-demo
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -151,7 +152,9 @@ jobs:
           - 'coqorg/coq:8.13'
       fail-fast: false  # don't stop jobs if one fails
     steps:
-      - uses: coq-community/docker-coq-action@${{ github.sha }}
+      - *setup-coq-demo
+      - *setup-docker-coq-action
+      - uses: './docker-coq-action'
         with:
           opam_file: 'coq-demo.opam'
           custom_image: ${{ matrix.image }}
@@ -168,7 +171,6 @@ jobs:
 
   demo-6:
     name: custom_image / docker-coq / apt-get
-    needs: setup-coq-demo
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -176,7 +178,9 @@ jobs:
           - 'coqorg/coq:8.13'
       fail-fast: false  # don't stop jobs if one fails
     steps:
-      - uses: coq-community/docker-coq-action@${{ github.sha }}
+      - *setup-coq-demo
+      - *setup-docker-coq-action
+      - uses: './docker-coq-action'
         with:
           opam_file: 'coq-demo.opam'
           custom_image: ${{ matrix.image }}

--- a/.github/workflows/coq-demo.yml
+++ b/.github/workflows/coq-demo.yml
@@ -25,16 +25,16 @@ jobs:
         ocaml_version: ['4.07-flambda']
       fail-fast: false  # don't stop jobs if one fails
     steps:
-      - &setup-coq-demo
-        uses: actions/checkout@v2
+      # BEGIN GHA_TEST_ENV
+      - uses: actions/checkout@v2
         with:
           repository: 'erikmd/docker-coq-github-action-demo'
           ref: 'master'
-      - &setup-docker-coq-action
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
         with:
           path: 'docker-coq-action'
       - uses: './docker-coq-action'
+        # END GHA_TEST_ENV
         with:
           opam_file: 'coq-demo.opam'
           coq_version: ${{ matrix.coq_version }}
@@ -51,9 +51,16 @@ jobs:
           # see https://hub.docker.com/r/mathcomp/mathcomp#supported-tags
       fail-fast: false  # don't stop jobs if one fails
     steps:
-      - *setup-coq-demo
-      - *setup-docker-coq-action
+      # BEGIN GHA_TEST_ENV
+      - uses: actions/checkout@v2
+        with:
+          repository: 'erikmd/docker-coq-github-action-demo'
+          ref: 'master'
+      - uses: actions/checkout@v2
+        with:
+          path: 'docker-coq-action'
       - uses: './docker-coq-action'
+        # END GHA_TEST_ENV
         with:
           opam_file: 'coq-demo.opam'
           custom_image: ${{ matrix.image }}
@@ -71,9 +78,16 @@ jobs:
           - 'coqorg/coq:8.13'
       fail-fast: false  # don't stop jobs if one fails
     steps:
-      - *setup-coq-demo
-      - *setup-docker-coq-action
+      # BEGIN GHA_TEST_ENV
+      - uses: actions/checkout@v2
+        with:
+          repository: 'erikmd/docker-coq-github-action-demo'
+          ref: 'master'
+      - uses: actions/checkout@v2
+        with:
+          path: 'docker-coq-action'
       - uses: './docker-coq-action'
+        # END GHA_TEST_ENV
         with:
           # As the install/script/uninstall fields are overridden,
           # the "opam_file" field is unneeded in this example job.
@@ -111,9 +125,16 @@ jobs:
           - 'coqorg/coq:8.13'
       fail-fast: false  # don't stop jobs if one fails
     steps:
-      - *setup-coq-demo
-      - *setup-docker-coq-action
+      # BEGIN GHA_TEST_ENV
+      - uses: actions/checkout@v2
+        with:
+          repository: 'erikmd/docker-coq-github-action-demo'
+          ref: 'master'
+      - uses: actions/checkout@v2
+        with:
+          path: 'docker-coq-action'
       - uses: './docker-coq-action'
+        # END GHA_TEST_ENV
         with:
           custom_image: ${{ matrix.image }}
           custom_script: |
@@ -152,9 +173,16 @@ jobs:
           - 'coqorg/coq:8.13'
       fail-fast: false  # don't stop jobs if one fails
     steps:
-      - *setup-coq-demo
-      - *setup-docker-coq-action
+      # BEGIN GHA_TEST_ENV
+      - uses: actions/checkout@v2
+        with:
+          repository: 'erikmd/docker-coq-github-action-demo'
+          ref: 'master'
+      - uses: actions/checkout@v2
+        with:
+          path: 'docker-coq-action'
       - uses: './docker-coq-action'
+        # END GHA_TEST_ENV
         with:
           opam_file: 'coq-demo.opam'
           custom_image: ${{ matrix.image }}
@@ -178,9 +206,16 @@ jobs:
           - 'coqorg/coq:8.13'
       fail-fast: false  # don't stop jobs if one fails
     steps:
-      - *setup-coq-demo
-      - *setup-docker-coq-action
+      # BEGIN GHA_TEST_ENV
+      - uses: actions/checkout@v2
+        with:
+          repository: 'erikmd/docker-coq-github-action-demo'
+          ref: 'master'
+      - uses: actions/checkout@v2
+        with:
+          path: 'docker-coq-action'
       - uses: './docker-coq-action'
+        # END GHA_TEST_ENV
         with:
           opam_file: 'coq-demo.opam'
           custom_image: ${{ matrix.image }}

--- a/.github/workflows/python-demo.yml
+++ b/.github/workflows/python-demo.yml
@@ -1,0 +1,46 @@
+name: Docker-based CI
+on:
+  push:
+    branches:
+      - master  # forall push/merge in master
+  pull_request:
+    branches:
+      - "**"  # forall submitted Pull Requests
+jobs:
+
+  # This job illustrates the fact that docker-coq-action is "coq-agnostic"
+  # and can be used with any Docker image.
+
+  # The two fields that are required to address this use case are:
+  # https://github.com/coq-community/docker-coq-action#custom_image
+  # https://github.com/coq-community/docker-coq-action#custom_script
+
+  python-demo:
+    name: docker-coq-action / python
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image:
+          - 'python:3'
+      fail-fast: false  # don't stop jobs if one fails
+    steps:
+      - uses: actions/checkout@v2
+        # This "with" clause must be removed if the GHA .yml file is committed
+        # in your own Python project repository:
+        with:
+          repository: 'erikmd/poc-github-ci'
+          ref: 'master'
+      - uses: coq-community/docker-coq-action@${{ github.sha }}
+        with:
+          custom_image: ${{ matrix.image }}
+          custom_script: |
+            python --version
+            startGroup "Install dependencies"
+              pip install --no-cache-dir --upgrade pip
+              pip install --no-cache-dir -r requirements.txt
+            endGroup
+            startGroup "Run tests"
+              pytest *.py
+            endGroup
+        # in case there is a permission mismatch issue at GHA cleanup time,
+        # see https://github.com/coq-community/docker-coq-action#permissions

--- a/.github/workflows/python-demo.yml
+++ b/.github/workflows/python-demo.yml
@@ -8,13 +8,14 @@ on:
       - "**"  # forall submitted Pull Requests
 jobs:
 
+  # ######################################################################
   # This job illustrates the fact that docker-coq-action is "coq-agnostic"
   # and can be used with any Docker image.
-
+  #
   # The two fields that are required to address this use case are:
   # https://github.com/coq-community/docker-coq-action#custom_image
   # https://github.com/coq-community/docker-coq-action#custom_script
-
+  # ######################################################################
   python-demo:
     name: docker-coq-action / python
     runs-on: ubuntu-latest
@@ -30,7 +31,15 @@ jobs:
         with:
           repository: 'erikmd/poc-github-ci'
           ref: 'master'
-      - uses: coq-community/docker-coq-action@${{ github.sha }}
+      # This step must be removed if the GHA .yml file is committed
+      # in your own Python project repository:
+      - uses: actions/checkout@v2
+        with:
+          path: 'docker-coq-action'
+      # This "uses" clause must be replaced, if the GHA .yml file is committed
+      # in your own Python project repository, with
+      # - uses: coq-community/docker-coq-action@v1
+      - uses: './docker-coq-action'
         with:
           custom_image: ${{ matrix.image }}
           custom_script: |


### PR DESCRIPTION
* Closing https://github.com/coq-community/docker-coq-action/issues/46

This new feature adds 7 more GHA jobs, which are intended to both:

* illustrate some typical use cases / "workflows" of `coq-community/docker-coq-action`
* and ease the test/review of new features,

without needing to open another accompanying PR in https://github.com/erikmd/docker-coq-github-action-demo;

also note that no Coq code is committed along with this PR, thanks to the `repository:` field of [`actions/checkout`](https://github.com/actions/checkout).