### PR TITLE
feat: Allow automatic install of system dependencies (needs opam 2.1)

### DIFF
--- a/.github/workflows/coq-demo.yml
+++ b/.github/workflows/coq-demo.yml
@@ -270,7 +270,7 @@ jobs:
           before_script: |
             startGroup "Install APT dependencies"
               cat /etc/os-release
-              sudo apt-get update -y -q
+              # sudo apt-get update -y -q # this mandatory command is already run in install step by default
               sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -q --no-install-recommends \
                 emacs \
                 tree  # for instance

--- a/.github/workflows/coq-demo.yml
+++ b/.github/workflows/coq-demo.yml
@@ -237,10 +237,42 @@ jobs:
           OPAMWITHTEST: 'true'
           ex_var: 'ex_value'
 
-  # The following job illustrates the installation of additional Debian packages.
+  # The following two jobs illustrate the installation of system packages.
 
   demo-6:
-    name: custom_image / docker-coq / opam / apt-get
+    name: custom_image / docker-coq / opam / auto install depexts
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image:
+          - 'coqorg/coq:dev'
+      fail-fast: false  # don't stop jobs if one fails
+    steps:
+      ################################################################
+      # Begin GHA_TEST_ENV # You should remove this GHA_TEST_ENV block
+      #                    # if you copy this demo workflow elsewhere!
+      - uses: actions/checkout@v2
+        with:
+          repository: 'erikmd/docker-coq-github-action-demo'
+          ref: 'master'
+      - uses: actions/checkout@v2
+        with:
+          path: 'docker-coq-action'
+      - uses: './docker-coq-action'
+        # End GHA_TEST_ENV
+        ##################
+        # - uses: actions/checkout@v2
+        # - uses: coq-community/docker-coq-action@v1
+        with:
+          opam_file: 'coq-depexts-test.opam'
+          custom_image: ${{ matrix.image }}
+          after_script: |
+            startGroup "Post-test"
+              gappa --version
+            endGroup
+
+  demo-7:
+    name: custom_image / docker-coq / opam / apt-get install more
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -284,7 +316,7 @@ jobs:
 
   # The following job illustrates the upload of generated artifacts.
 
-  demo-7:
+  demo-8:
     name: custom_image / docker-coq / opam+make / upload-artifacts
     runs-on: ubuntu-latest
     strategy:

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ it will run (by default) the following commands:
 opam config list; opam repo list; opam list
 opam pin add -n -y -k path coq-proj folder
 opam update -y
-opam install -y -j 2 coq-proj --deps-only
+opam install --confirm-level=unsafe-yes -j 2 coq-proj --deps-only
 opam list
 opam install -y -v -j 2 coq-proj
 opam list
@@ -220,7 +220,7 @@ Default:
 startGroup "Install dependencies"
   opam pin add -n -y -k path $PACKAGE $WORKDIR
   opam update -y
-  opam install -y -j 2 $PACKAGE --deps-only
+  opam install --confirm-level=unsafe-yes -j 2 $PACKAGE --deps-only
 endGroup
 ```
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ it will run (by default) the following commands:
 
 ```bash
 opam config list; opam repo list; opam list
+sudo apt-get update -y -q
 opam pin add -n -y -k path coq-proj folder
 opam update -y
 opam install --confirm-level=unsafe-yes -j 2 coq-proj --deps-only
@@ -81,6 +82,11 @@ opam install -y -v -j 2 coq-proj
 opam list
 opam remove coq-proj
 ```
+
+The `apt-get` command and the `--confirm-level=unsafe-yes` opam option
+are necessary for automatic installation of system packages
+that may be required by `coq-proj.opam`, as described in the
+[opam 2.1 release notes](https://opam.ocaml.org/blog/opam-2-1-0/#Seamless-integration-of-System-dependencies-handling-a-k-a-quot-depexts-quot).
 
 ## Using the GitHub Action
 
@@ -218,6 +224,7 @@ Default:
 
 ```bash
 startGroup "Install dependencies"
+  sudo apt-get update -y -q
   opam pin add -n -y -k path $PACKAGE $WORKDIR
   opam update -y
   opam install --confirm-level=unsafe-yes -j 2 $PACKAGE --deps-only

--- a/README.md
+++ b/README.md
@@ -667,7 +667,7 @@ steps:
       before_script: |
         startGroup "Install APT dependencies"
           cat /etc/os-release  # Print the Debian OS version
-          sudo apt-get update -y -q  # Mandatory
+          # sudo apt-get update -y -q # this mandatory command is already run in install step by default
           sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -q --no-install-recommends \
             emacs \
             tree  # for instance

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ inputs:
       startGroup "Install dependencies"
         opam pin add -n -y -k path $PACKAGE $WORKDIR
         opam update -y
-        opam install -y -j 2 $PACKAGE --deps-only
+        opam install --confirm-level=unsafe-yes -j 2 $PACKAGE --deps-only
       endGroup
   after_install:
     description: 'Customizable script run after "install".'

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,7 @@ inputs:
     description: 'Customizable script to install the opam dependencies.'
     default: |
       startGroup "Install dependencies"
+        sudo apt-get update -y -q
         opam pin add -n -y -k path $PACKAGE $WORKDIR
         opam update -y
         opam install --confirm-level=unsafe-yes -j 2 $PACKAGE --deps-only


### PR DESCRIPTION
Since all Docker images switched to opam 2.1, it might make sense to enable installing depext dependencies automatically (in this case, Debian system packages).

However, the current definition of the `install` task does not permit installing depext dependencies, since a simple `-y`/`--yes` does not suffice for system packages, instead one [has to](https://www.ocamlpro.com/blog/2021_08_04_opam_2.1.0_is_released):
>  set OPAMCONFIRMLEVEL=unsafe-yes or --confirm-level=unsafe-yes to launch non interactive system package commands.

Note that Docker-Coq-Action users will still have to run `sudo apt-get update -y -q` somewhere before the dependency installation to get system packags, but this is already documented in the wiki. The `--confirm-level=unsafe-yes` is much more obscure to figure out and set manually, so I propose we set it by default here.