### PR TITLE
feat: Drop support of `ocaml_version: "minimal"`

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,7 @@ The version of OCaml.
 
 Default: `"default"` (= Docker-Coq's default OCaml version for the given Coq version).
 
-Among `"minimal"` (*deprecated, to be removed after 27 June 2022 AOE*),
-`"default"`, `"4.02"`, `"4.05"`, `"4.07-flambda"`, `"4.08-flambda"`, `"4.09-flambda"`, `"4.10-flambda"`, `"4.11-flambda"`, `"4.12-flambda"`, `"4.13-flambda"`, `"4.14-flambda"`…
+Among `"default"`, `"4.02"`, `"4.05"`, `"4.07-flambda"`, `"4.08-flambda"`, `"4.09-flambda"`, `"4.10-flambda"`, `"4.11-flambda"`, `"4.12-flambda"`, `"4.13-flambda"`, `"4.14-flambda"`…
 
 **Warning!** not all OCaml versions are available with all Coq versions.
 

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
     description: '"8.X", "latest", "dev", "8.X-native", "latest-native", or "dev-native"'
     default: 'latest'
   ocaml_version:
-    description: '"minimal" (deprecated), "default", "4.02", "4.05", or "4.XX-flambda", see https://github.com/coq-community/docker-coq/wiki#ocaml-versions-policy'
+    description: '"default", "4.02", "4.05", or "4.XX-flambda", see https://github.com/coq-community/docker-coq/wiki#ocaml-versions-policy'
     default: 'default'
   before_install:
     description: 'Customizable script run before "install".'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -56,7 +56,7 @@ usage() {
 Usage:
   INPUT_OPAM_FILE=file.opam \\
   INPUT_COQ_VERSION=8.11 \\
-  INPUT_OCAML_VERSION=minimal \\
+  INPUT_OCAML_VERSION=default \\
   INPUT_CUSTOM_SCRIPT='...' \\
   INPUT_CUSTOM_IMAGE=''
   INPUT_EXPORT=''
@@ -65,7 +65,7 @@ Usage:
 Options:
 INPUT_OPAM_FILE: the path of the .opam file (or a directory), relative to the repo root
 INPUT_COQ_VERSION: the version of Coq (without patch-level)
-INPUT_OCAML_VERSION: the version of OCaml (minimal, 4.07-flambda, 4.09-flambda)
+INPUT_OCAML_VERSION: the version of OCaml (default, 4.07-flambda, 4.09-flambda)
 INPUT_CUSTOM_SCRIPT: the main script run in the container
 INPUT_CUSTOM_IMAGE: the name of the Docker image to pull
 INPUT_EXPORT: the space-separated list of env variables to export
@@ -139,34 +139,12 @@ EOF
         # HERE, "ocaml_version" is nonempty
 
         if [ "$INPUT_OCAML_VERSION" = 'minimal' ]; then
-        # TODO: uncomment this when the 'minimal' deprecation phase ends.
-        #     echo "ERROR: ocaml_version: 'minimal' is not supported anymore."
-        #     exit 1
-        # TODO: remove the following when the 'minimal' deprecation phase ends.
-
         # Rely on line 'echo "::add-matcher::$HOME/coq.json"' above.
             cat <<EOF
 File "./.github/workflows", line 1, characters 0-1:
-Warning: Setting ocaml_version to "minimal" is DEPRECATED (to be removed on 2022-06-27 AOE): please use "default", or a specific ocaml_version in https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/workflow (see https://github.com/coq-community/docker-coq-action#ocaml_version for details).
+Error: Setting ocaml_version to "minimal" is NOT SUPPORTED ANYMORE: please use "default", or a specific ocaml_version in https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/workflow (see https://github.com/coq-community/docker-coq-action#ocaml_version for details).
 EOF
-            case "$INPUT_COQ_VERSION" in
-                8.4 | 8.5 | 8.6)
-                    OCAML_VERSION='4.02';;
-                8.4.* | 8.5.* | 8.6.*)
-                    OCAML_VERSION='4.02.3';;
-                8.7 | 8.8 | 8.9 | 8.10 | 8.11 | 8.12 | 8.13 | 8.14 | 8.15 | latest)
-                    OCAML_VERSION='4.05';;
-                8.7.* | 8.8.* | 8.9.* | 8.10.* | 8.11.* | 8.12.* | 8.13.* | 8.14.* | 8.15.*)
-                    OCAML_VERSION='4.05.0';;
-                dev | 8.16)
-                    OCAML_VERSION='4.09-flambda';;
-                8.16*)
-                    OCAML_VERSION='4.09.0-flambda';;
-                *)
-                    echo "ERROR: ocaml_version: 'minimal' unrecognized for this coq_version."
-                    exit 1
-            esac
-            COQ_IMAGE="coqorg/coq:${INPUT_COQ_VERSION}-ocaml-${OCAML_VERSION}"
+            exit 1
         else
             COQ_IMAGE="coqorg/coq:${INPUT_COQ_VERSION}-ocaml-${INPUT_OCAML_VERSION}"
         fi


### PR DESCRIPTION
As the docker-coq-action is intended to act as a GHA **facade** (to simplify the CI testing of opam projects using a Docker-Coq image or a custom one), and as the mapping between valid `coq_version` and `ocaml_version` already is the responsibility of the Docker-Coq registry, it appears irrelevant to also maintain one similar mapping in docker-coq-action's `entrypoint.sh`.

Still, the value `ocaml_version: "minimal"` can be safely emulated with:

```
- uses: coq-community/docker-coq-action@v1
  with:
    ocaml_version: "4.05"
      # for 8.10 <= coq_version <= 8.15
      #
      # or:
      #
    ocaml_version: "4.09-flambda"
      # for coq_version >= 8.16
```

Finally, it can be noted that setting `ocaml_version: "default"` is useful to directly rely on Docker-Coq's default tag, regarding the ocaml version: see https://github.com/coq-community/docker-coq/wiki#ocaml-versions-policy