### PR TITLE
Update README.md with new chown command

### DIFF
--- a/.github/workflows/coq-demo.yml
+++ b/.github/workflows/coq-demo.yml
@@ -115,13 +115,13 @@ jobs:
           # As the install/script/uninstall fields are overridden,
           # the "opam_file" field is unneeded in this example job.
           custom_image: ${{ matrix.image }}
+          before_install: |
+            startGroup "Workaround permission issue"
+              sudo chown -R coq:coq .
+            endGroup
           install: |
             startGroup "Install dependencies"
               opam install -y -j 2 coq-mathcomp-ssreflect
-            endGroup
-          before_script: |
-            startGroup "Workaround permission issue"
-              sudo chown -R coq:coq .
             endGroup
           script: |
             startGroup "Build project"

--- a/README.md
+++ b/README.md
@@ -613,7 +613,7 @@ strategy:
         with:
           opam_file: 'folder/coq-proj.opam'
           custom_image: ${{ matrix.image }}
-          before_script: |
+          before_install: |
             startGroup "Workaround permission issue"
               sudo chown -R coq:coq .
             endGroup


### PR DESCRIPTION
As discussed [on Zulip](https://coq.zulipchat.com/#narrow/stream/237658-MetaCoq/topic/CI.20failure/near/343379811), at least for MetaCoq we need to fix permissions already before the installation, otherwise installing dependencies via `opam` fails.