### PR TITLE
Enable usage of github runner file commands

### DIFF
--- a/.github/workflows/coq-demo.yml
+++ b/.github/workflows/coq-demo.yml
@@ -228,6 +228,8 @@ jobs:
         with:
           opam_file: 'coq-demo.opam'
           custom_image: ${{ matrix.image }}
+          install: |
+            # don't wait CI time installing
           before_script: |
             startGroup "Toy example"
               echo "ex_var=$ex_var" | tee -a $GITHUB_STEP_SUMMARY

--- a/.github/workflows/coq-demo.yml
+++ b/.github/workflows/coq-demo.yml
@@ -228,28 +228,21 @@ jobs:
         with:
           opam_file: 'coq-demo.opam'
           custom_image: ${{ matrix.image }}
-          install: |
-            # don't wait CI time installing
-          before_script: |
+          custom_script: |
             startGroup "Toy example"
-              find "$(dirname "$(dirname "$GITHUB_STEP_SUMMARY")")"
-              ls -la "$(dirname "$(dirname "$GITHUB_STEP_SUMMARY")")"
-              ls -la "$(dirname "$GITHUB_STEP_SUMMARY")"
-              sudo chmod -R a+rw "$(dirname "$GITHUB_STEP_SUMMARY")"
-              ls -la "$(dirname "$GITHUB_STEP_SUMMARY")"
-              ls -la $GITHUB_STEP_SUMMARY || true
-              echo "ex_var=$ex_var" | tee -a $GITHUB_STEP_SUMMARY
-              echo "ex_var_global=$ex_var" | tee -a $GITHUB_ENV
               [ "$ex_var" = "ex_value" ]
+              echo "GITHUB_ENV=$GITHUB_ENV"
+              echo "ex_var_global=$ex_var.final" | tee -a $GITHUB_ENV
             endGroup
-          export: 'ex_var OPAMWITHTEST GITHUB_STEP_SUMMARY'  # space-separated list of variables
+          export: 'ex_var GITHUB_ENV'  # space-separated list of variables
+          # TODO cleanup, redo OPAMWITHTEST
         env:
           OPAMWITHTEST: 'true'
           ex_var: 'ex_value'
       - run: |
           # test persistence of ex_var_global via $GITHUB_ENV
           echo "ex_var_global=$ex_var_global"
-          [ "$ex_var_global" = "ex_value" ]
+          [ "$ex_var_global" = "ex_value.final" ]
 
   # The following two jobs illustrate the installation of system packages.
 

--- a/.github/workflows/coq-demo.yml
+++ b/.github/workflows/coq-demo.yml
@@ -232,7 +232,8 @@ jobs:
             # don't wait CI time installing
           before_script: |
             startGroup "Toy example"
-            ls -la $GITHUB_STEP_SUMMARY
+              find "$(dirname "$(dirname "$GITHUB_STEP_SUMMARY")")"
+              ls -la $GITHUB_STEP_SUMMARY
               echo "ex_var=$ex_var" | tee -a $GITHUB_STEP_SUMMARY
               [ "$ex_var" = "ex_value" ]
             endGroup

--- a/.github/workflows/coq-demo.yml
+++ b/.github/workflows/coq-demo.yml
@@ -232,6 +232,7 @@ jobs:
             # don't wait CI time installing
           before_script: |
             startGroup "Toy example"
+            ls -la $GITHUB_STEP_SUMMARY
               echo "ex_var=$ex_var" | tee -a $GITHUB_STEP_SUMMARY
               [ "$ex_var" = "ex_value" ]
             endGroup

--- a/.github/workflows/coq-demo.yml
+++ b/.github/workflows/coq-demo.yml
@@ -237,14 +237,19 @@ jobs:
               ls -la "$(dirname "$GITHUB_STEP_SUMMARY")"
               sudo chmod -R a+rw "$(dirname "$GITHUB_STEP_SUMMARY")"
               ls -la "$(dirname "$GITHUB_STEP_SUMMARY")"
-              ls -la $GITHUB_STEP_SUMMARY
+              ls -la $GITHUB_STEP_SUMMARY || true
               echo "ex_var=$ex_var" | tee -a $GITHUB_STEP_SUMMARY
+              echo "ex_var_global=$ex_var" | tee -a $GITHUB_ENV
               [ "$ex_var" = "ex_value" ]
             endGroup
           export: 'ex_var OPAMWITHTEST GITHUB_STEP_SUMMARY'  # space-separated list of variables
         env:
           OPAMWITHTEST: 'true'
           ex_var: 'ex_value'
+      - run: |
+          # test persistence of ex_var_global via $GITHUB_ENV
+          echo "ex_var_global=$ex_var_global"
+          [ "$ex_var_global" = "ex_value" ]
 
   # The following two jobs illustrate the installation of system packages.
 

--- a/.github/workflows/coq-demo.yml
+++ b/.github/workflows/coq-demo.yml
@@ -235,6 +235,8 @@ jobs:
               find "$(dirname "$(dirname "$GITHUB_STEP_SUMMARY")")"
               ls -la "$(dirname "$(dirname "$GITHUB_STEP_SUMMARY")")"
               ls -la "$(dirname "$GITHUB_STEP_SUMMARY")"
+              sudo chmod -R a+rw "$(dirname "$GITHUB_STEP_SUMMARY")"
+              ls -la "$(dirname "$GITHUB_STEP_SUMMARY")"
               ls -la $GITHUB_STEP_SUMMARY
               echo "ex_var=$ex_var" | tee -a $GITHUB_STEP_SUMMARY
               [ "$ex_var" = "ex_value" ]

--- a/.github/workflows/coq-demo.yml
+++ b/.github/workflows/coq-demo.yml
@@ -230,10 +230,10 @@ jobs:
           custom_image: ${{ matrix.image }}
           before_script: |
             startGroup "Toy example"
-              echo "ex_var=$ex_var"
+              echo "ex_var=$ex_var" | tee -a $GITHUB_STEP_SUMMARY
               [ "$ex_var" = "ex_value" ]
             endGroup
-          export: 'ex_var OPAMWITHTEST'  # space-separated list of variables
+          export: 'ex_var OPAMWITHTEST GITHUB_STEP_SUMMARY'  # space-separated list of variables
         env:
           OPAMWITHTEST: 'true'
           ex_var: 'ex_value'

--- a/.github/workflows/coq-demo.yml
+++ b/.github/workflows/coq-demo.yml
@@ -405,25 +405,29 @@ jobs:
         id: docker-coq-action
         env:
           # Pass string data to docker-coq-action
-          some_var: 'Test successful!'
+          after_ok: 'Test successful!'
         with:
-          export: 'COQ_IMAGE some_var'
+          export: 'COQ_IMAGE after_ok'
           custom_image: ${{ matrix.image }}
           opam_file: 'coq-demo.opam'
           before_script: |
-            # Pass Docker image tag to next step
+            # Pass step outputs (Docker image name) to next step
             echo "docker_image=$COQ_IMAGE" >> "$GITHUB_OUTPUT"
           after_script: |
-            # Pass Coq version string to next step
+            # Pass env vars (Coq version string...) to next step
             echo "coq_version=$(opam var coq:version)" >> "$GITHUB_ENV"
+            echo "some_variable=expected_value" >> "$GITHUB_ENV"
             # Display Markdown summary
-            [ -n "$some_var" ]
-            echo "### $some_var :rocket:" >> "$GITHUB_STEP_SUMMARY"
+            [ -n "$after_ok" ]
+            echo "### $after_ok :rocket:" >> "$GITHUB_STEP_SUMMARY"
       - name: Next step
         env:
           docker_image: ${{ steps.docker-coq-action.outputs.docker_image}}
         run: |
+          : Summary
           echo "Previous step pulled Docker image: $docker_image"
           [ -n "$docker_image" ]
           echo "Previous step used: coq_version=$coq_version"
           [ -n "$coq_version" ]
+          echo "some_variable=$some_variable"
+          [ "$some_variable" = "expected_value" ]

--- a/.github/workflows/coq-demo.yml
+++ b/.github/workflows/coq-demo.yml
@@ -233,6 +233,8 @@ jobs:
           before_script: |
             startGroup "Toy example"
               find "$(dirname "$(dirname "$GITHUB_STEP_SUMMARY")")"
+              ls -la "$(dirname "$(dirname "$GITHUB_STEP_SUMMARY")")"
+              ls -la "$(dirname "$GITHUB_STEP_SUMMARY")"
               ls -la $GITHUB_STEP_SUMMARY
               echo "ex_var=$ex_var" | tee -a $GITHUB_STEP_SUMMARY
               [ "$ex_var" = "ex_value" ]

--- a/README.md
+++ b/README.md
@@ -653,7 +653,7 @@ Recall that `docker-coq-action` runs your CI script in a Docker container,
 the filesystem of which being isolated from the GitHub runner.
 
 Still, `docker-coq-action` bind-mounts some special paths for
-[GitHub Actions environment files](https://docs.github.com/fr/actions/using-workflows/workflow-commands-for-github-actions#environment-files),
+[GitHub Actions environment files](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files),
 so that `"$GITHUB_ENV"`, `"$GITHUB_OUTPUT"`, and `"$GITHUB_STEP_SUMMARY"` can be used
 in (parts of) the [`custom_script`](#custom_script) in order to pass environment
 variables or step outputs to the following steps, or set a Markdown summary.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,9 +25,9 @@ echo "GITHUB_REPOSITORY=$GITHUB_REPOSITORY"
 echo "RUNNER_OS=$RUNNER_OS"
 echo "RUNNER_TEMP=$RUNNER_TEMP"
 echo "RUNNER_WORKSPACE=$RUNNER_WORKSPACE"
-# GITHUB_ENV is somewhat arbitrary, might be something like /home/runner/work/_temp/_runner_file_commands/set_env_87406d6e-4979-4d42-98e1-3dab1f48b13a or /github/file_commands/set_env_3b186eb5-242d-4edf-b107-b13e98e56988
-GITHUB_RUNNER_FILE_COMMANDS_DIR="$(dirname "$GITHUB_ENV")"
-echo "GITHUB_RUNNER_FILE_COMMANDS_DIR=$GITHUB_RUNNER_FILE_COMMANDS_DIR"
+# GITHUB_ENV is somewhat arbitrary, all of the file variables should be similar, might be something like /home/runner/work/_temp/_runner_file_commands/set_env_87406d6e-4979-4d42-98e1-3dab1f48b13a or /github/file_commands/set_env_3b186eb5-242d-4edf-b107-b13e98e56988
+DIR_GITHUB_RUNNER_FILE_COMMANDS="$(dirname "$GITHUB_ENV")"
+echo "DIR_GITHUB_RUNNER_FILE_COMMANDS=$DIR_GITHUB_RUNNER_FILE_COMMANDS"
 # Assuming you used https://github.com/actions/checkout,
 # the GITHUB_WORKSPACE variable corresponds to the following host dir:
 # ${RUNNER_WORKSPACE}/${GITHUB_REPOSITORY#*/}, see also
@@ -206,7 +206,7 @@ endGroup
 # shellcheck disable=SC2046,SC2086
 docker run --pull=never -i --init --rm --name=COQ $( [ -n "$INPUT_EXPORT" ] && printf -- "-e %s " $INPUT_EXPORT ) -e WORKDIR="$WORKDIR" -e PACKAGE="$PACKAGE" \
        -v "$HOST_WORKSPACE_REPO:$PWD" -w "$PWD" \
-       -v "$GITHUB_RUNNER_FILE_COMMANDS_DIR:$GITHUB_RUNNER_FILE_COMMANDS_DIR" \
+       -v "$DIR_GITHUB_RUNNER_FILE_COMMANDS:$DIR_GITHUB_RUNNER_FILE_COMMANDS" \
        "$COQ_IMAGE" /bin/bash --login -c "
 exec 2>&1 ; endGroup () {  {  init_opts=\"\$-\"; set +x ; } 2> /dev/null; if [ -n \"\$startTime\" ]; then endTime=\$(date -u +%s); echo \"::endgroup::\"; printf \"↳ \"; date -u -d \"@\$((endTime - startTime))\" '+%-Hh %-Mm %-Ss'; echo; unset startTime; else echo 'Error: missing startGroup command.'; case \"\$init_opts\" in  *x*) set -x ;; esac; return 1; fi; case \"\$init_opts\" in  *x*) set -x ;; esac; } ; startGroup () {  {  init_opts=\"\$-\"; set +x ; } 2> /dev/null; if [ -n \"\$startTime\" ]; then endGroup; fi; if [ \$# -ge 1 ]; then groupTitle=\"\$*\"; else groupTitle=\"Unnamed group\"; fi; echo; echo \"::group::\$groupTitle\"; startTime=\$(date -u +%s); case \"\$init_opts\" in  *x*) set -x ;; esac; } # generated from helper.sh
 export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '; set -ex

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -213,7 +213,7 @@ endGroup
 
 ## Note to docker-coq-action maintainers: Run ./helper.sh gen & Copy min.sh
 # shellcheck disable=SC2046,SC2086
-docker run --pull=never -i --init --rm --name=COQ $( [ -n "$INPUT_EXPORT" ] && printf -- "-e %s " $INPUT_EXPORT ) -e WORKDIR="$WORKDIR" -e PACKAGE="$PACKAGE" \
+echorun docker run --pull=never -i --init --rm --name=COQ $( [ -n "$INPUT_EXPORT" ] && printf -- "-e %s " $INPUT_EXPORT ) -e WORKDIR="$WORKDIR" -e PACKAGE="$PACKAGE" \
        -v "$HOST_WORKSPACE_REPO:$PWD" -w "$PWD" \
        -v "$DIR_GITHUB_RUNNER_FILE_COMMANDS:$DIR_GITHUB_RUNNER_FILE_COMMANDS" \
        "$COQ_IMAGE" /bin/bash --login -c "

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,7 +31,7 @@ echo "RUNNER_WORKSPACE=$RUNNER_WORKSPACE"
 # so $(dirname "$GITHUB_ENV") is typically /home/runner/work/_temp/_runner_file_commands on the host.
 # We also notice that $RUNNER_WORKSPACE is typically /home/runner/work/${GITHUB_REPOSITORY#*/} (e.g. /home/runner/work/docker-coq-action).
 # Hence this hardcoded yet as-general-as-possible path:
-DIR_GITHUB_RUNNER_FILE_COMMANDS="${RUNNER_WORKSPACE#*/}/_temp/_runner_file_commands"
+DIR_GITHUB_RUNNER_FILE_COMMANDS="${RUNNER_WORKSPACE%*/}/_temp/_runner_file_commands"
 echo "DIR_GITHUB_RUNNER_FILE_COMMANDS=$DIR_GITHUB_RUNNER_FILE_COMMANDS"
 
 # Assuming you used https://github.com/actions/checkout,
@@ -201,14 +201,14 @@ if test -z "$INPUT_CUSTOM_SCRIPT_EXPANDED"; then
     exit 1
 fi
 
-startGroup "set permissions for GitHub Actions runner command files in $DIR_GITHUB_RUNNER_FILE_COMMANDS"
-
-chmod -R a+rw "$DIR_GITHUB_RUNNER_FILE_COMMANDS"
-chmod a+rwx "$DIR_GITHUB_RUNNER_FILE_COMMANDS/.." || true
-echorun ls -la "$DIR_GITHUB_RUNNER_FILE_COMMANDS"
-echorun ls -la "$DIR_GITHUB_RUNNER_FILE_COMMANDS/.." || true
-
-endGroup
+# startGroup "set permissions for GitHub Actions runner command files in $DIR_GITHUB_RUNNER_FILE_COMMANDS"
+# 
+# chmod -Rv a+rw "$DIR_GITHUB_RUNNER_FILE_COMMANDS"
+# chmod -v a+rwx "$DIR_GITHUB_RUNNER_FILE_COMMANDS/.." || true
+# echorun ls -la "$DIR_GITHUB_RUNNER_FILE_COMMANDS"
+# echorun ls -la "$DIR_GITHUB_RUNNER_FILE_COMMANDS/.." || true
+# 
+# endGroup
 
 startGroup "Pull docker image"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -196,7 +196,7 @@ if test -z "$INPUT_CUSTOM_SCRIPT_EXPANDED"; then
 fi
 
 # set permissions for GitHub Actions runner command files
-sudo chmod -R a=u "$DIR_GITHUB_RUNNER_FILE_COMMANDS"
+chmod -R a=u "$DIR_GITHUB_RUNNER_FILE_COMMANDS"
 
 startGroup "Pull docker image"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -198,7 +198,9 @@ fi
 startGroup "set permissions for GitHub Actions runner command files in $DIR_GITHUB_RUNNER_FILE_COMMANDS"
 
 chmod -R a+rw "$DIR_GITHUB_RUNNER_FILE_COMMANDS"
-ls -la "$DIR_GITHUB_RUNNER_FILE_COMMANDS"
+chmod a+rwx "$DIR_GITHUB_RUNNER_FILE_COMMANDS/.." || true
+echorun ls -la "$DIR_GITHUB_RUNNER_FILE_COMMANDS"
+echorun ls -la "$DIR_GITHUB_RUNNER_FILE_COMMANDS/.." || true
 
 endGroup
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,7 +31,7 @@ echo "RUNNER_WORKSPACE=$RUNNER_WORKSPACE"
 # so $(dirname "$GITHUB_ENV") is typically /home/runner/work/_temp/_runner_file_commands on the host.
 # We also notice that $RUNNER_WORKSPACE is typically /home/runner/work/${GITHUB_REPOSITORY#*/} (e.g. /home/runner/work/docker-coq-action).
 # Hence this hardcoded yet as-general-as-possible path:
-DIR_GITHUB_RUNNER_FILE_COMMANDS="${RUNNER_WORKSPACE%*/}/_temp/_runner_file_commands"
+DIR_GITHUB_RUNNER_FILE_COMMANDS="${RUNNER_WORKSPACE%/*}/_temp/_runner_file_commands"
 echo "DIR_GITHUB_RUNNER_FILE_COMMANDS=$DIR_GITHUB_RUNNER_FILE_COMMANDS"
 
 # Assuming you used https://github.com/actions/checkout,

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,10 +29,13 @@ echo "RUNNER_WORKSPACE=$RUNNER_WORKSPACE"
 # We want to bind-mount the dirname of $GITHUB_ENV.
 # $GITHUB_ENV is typically /home/runner/work/_temp/_runner_file_commands/set_env_87406d6e-4979-4d42-98e1-3dab1f48b13a
 # so $(dirname "$GITHUB_ENV") is typically /home/runner/work/_temp/_runner_file_commands on the host.
-# We also notice that $RUNNER_WORKSPACE is typically /home/runner/work/${GITHUB_REPOSITORY#*/} (e.g. /home/runner/work/docker-coq-action).
+# We also notice that $RUNNER_WORKSPACE is typically /home/runner/work/${GITHUB_REPOSITORY%/*} (e.g. /home/runner/work/docker-coq-action).
 # Hence this hardcoded yet as-general-as-possible path:
-DIR_GITHUB_RUNNER_FILE_COMMANDS="${RUNNER_WORKSPACE%/*}/_temp/_runner_file_commands"
-echo "DIR_GITHUB_RUNNER_FILE_COMMANDS=$DIR_GITHUB_RUNNER_FILE_COMMANDS"
+HOST_GITHUB_RUNNER_FILE_COMMANDS="${RUNNER_WORKSPACE%/*}/_temp/_runner_file_commands"
+# Another hardcoded path:
+DIR_FILE_COMMANDS="/github/file_commands"
+echo "HOST_GITHUB_RUNNER_FILE_COMMANDS=$HOST_GITHUB_RUNNER_FILE_COMMANDS"
+echo "DIR_FILE_COMMANDS=$DIR_FILE_COMMANDS"
 
 # Assuming you used https://github.com/actions/checkout,
 # the GITHUB_WORKSPACE variable corresponds to the following host dir:
@@ -221,7 +224,7 @@ endGroup
 # shellcheck disable=SC2046,SC2086
 docker run --pull=never -i --init --rm --name=COQ $( [ -n "$INPUT_EXPORT" ] && printf -- "-e %s " $INPUT_EXPORT ) -e WORKDIR="$WORKDIR" -e PACKAGE="$PACKAGE" \
        -v "$HOST_WORKSPACE_REPO:$PWD" -w "$PWD" \
-       -v "$DIR_GITHUB_RUNNER_FILE_COMMANDS:$DIR_GITHUB_RUNNER_FILE_COMMANDS" \
+       -v "$HOST_GITHUB_RUNNER_FILE_COMMANDS:$DIR_FILE_COMMANDS" \
        "$COQ_IMAGE" /bin/bash --login -c "
 exec 2>&1 ; endGroup () {  {  init_opts=\"\$-\"; set +x ; } 2> /dev/null; if [ -n \"\$startTime\" ]; then endTime=\$(date -u +%s); echo \"::endgroup::\"; printf \"↳ \"; date -u -d \"@\$((endTime - startTime))\" '+%-Hh %-Mm %-Ss'; echo; unset startTime; else echo 'Error: missing startGroup command.'; case \"\$init_opts\" in  *x*) set -x ;; esac; return 1; fi; case \"\$init_opts\" in  *x*) set -x ;; esac; } ; startGroup () {  {  init_opts=\"\$-\"; set +x ; } 2> /dev/null; if [ -n \"\$startTime\" ]; then endGroup; fi; if [ \$# -ge 1 ]; then groupTitle=\"\$*\"; else groupTitle=\"Unnamed group\"; fi; echo; echo \"::group::\$groupTitle\"; startTime=\$(date -u +%s); case \"\$init_opts\" in  *x*) set -x ;; esac; } # generated from helper.sh
 export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '; set -ex

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,6 +25,9 @@ echo "GITHUB_REPOSITORY=$GITHUB_REPOSITORY"
 echo "RUNNER_OS=$RUNNER_OS"
 echo "RUNNER_TEMP=$RUNNER_TEMP"
 echo "RUNNER_WORKSPACE=$RUNNER_WORKSPACE"
+# GITHUB_ENV is somewhat arbitrary, might be something like /home/runner/work/_temp/_runner_file_commands/set_env_87406d6e-4979-4d42-98e1-3dab1f48b13a or /github/file_commands/set_env_3b186eb5-242d-4edf-b107-b13e98e56988
+GITHUB_RUNNER_FILE_COMMANDS_DIR="$(dirname "$GITHUB_ENV")"
+echo "GITHUB_RUNNER_FILE_COMMANDS_DIR=$GITHUB_RUNNER_FILE_COMMANDS_DIR"
 # Assuming you used https://github.com/actions/checkout,
 # the GITHUB_WORKSPACE variable corresponds to the following host dir:
 # ${RUNNER_WORKSPACE}/${GITHUB_REPOSITORY#*/}, see also
@@ -203,6 +206,7 @@ endGroup
 # shellcheck disable=SC2046,SC2086
 docker run --pull=never -i --init --rm --name=COQ $( [ -n "$INPUT_EXPORT" ] && printf -- "-e %s " $INPUT_EXPORT ) -e WORKDIR="$WORKDIR" -e PACKAGE="$PACKAGE" \
        -v "$HOST_WORKSPACE_REPO:$PWD" -w "$PWD" \
+       -v "$GITHUB_RUNNER_FILE_COMMANDS_DIR:$GITHUB_RUNNER_FILE_COMMANDS_DIR" \
        "$COQ_IMAGE" /bin/bash --login -c "
 exec 2>&1 ; endGroup () {  {  init_opts=\"\$-\"; set +x ; } 2> /dev/null; if [ -n \"\$startTime\" ]; then endTime=\$(date -u +%s); echo \"::endgroup::\"; printf \"↳ \"; date -u -d \"@\$((endTime - startTime))\" '+%-Hh %-Mm %-Ss'; echo; unset startTime; else echo 'Error: missing startGroup command.'; case \"\$init_opts\" in  *x*) set -x ;; esac; return 1; fi; case \"\$init_opts\" in  *x*) set -x ;; esac; } ; startGroup () {  {  init_opts=\"\$-\"; set +x ; } 2> /dev/null; if [ -n \"\$startTime\" ]; then endGroup; fi; if [ \$# -ge 1 ]; then groupTitle=\"\$*\"; else groupTitle=\"Unnamed group\"; fi; echo; echo \"::group::\$groupTitle\"; startTime=\$(date -u +%s); case \"\$init_opts\" in  *x*) set -x ;; esac; } # generated from helper.sh
 export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '; set -ex

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -204,14 +204,12 @@ if test -z "$INPUT_CUSTOM_SCRIPT_EXPANDED"; then
     exit 1
 fi
 
-# startGroup "set permissions for GitHub Actions runner command files in $DIR_GITHUB_RUNNER_FILE_COMMANDS"
-# 
-# chmod -Rv a+rw "$DIR_GITHUB_RUNNER_FILE_COMMANDS"
-# chmod -v a+rwx "$DIR_GITHUB_RUNNER_FILE_COMMANDS/.." || true
-# echorun ls -la "$DIR_GITHUB_RUNNER_FILE_COMMANDS"
-# echorun ls -la "$DIR_GITHUB_RUNNER_FILE_COMMANDS/.." || true
-# 
-# endGroup
+startGroup "Set permissions for GHA runner command files in $DIR_FILE_COMMANDS"
+# a.k.a. $HOST_GITHUB_RUNNER_FILE_COMMANDS on the host.
+
+chmod -R a+rw "$DIR_FILE_COMMANDS"
+
+endGroup
 
 startGroup "Pull docker image"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -195,6 +195,9 @@ if test -z "$INPUT_CUSTOM_SCRIPT_EXPANDED"; then
     exit 1
 fi
 
+# set permissions for GitHub Actions runner command files
+sudo chmod -R a=u "$DIR_GITHUB_RUNNER_FILE_COMMANDS"
+
 startGroup "Pull docker image"
 
 echo COQ_IMAGE="$COQ_IMAGE"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -195,8 +195,12 @@ if test -z "$INPUT_CUSTOM_SCRIPT_EXPANDED"; then
     exit 1
 fi
 
-# set permissions for GitHub Actions runner command files
+startGroup "set permissions for GitHub Actions runner command files in $DIR_GITHUB_RUNNER_FILE_COMMANDS"
+
 chmod -R a+rw "$DIR_GITHUB_RUNNER_FILE_COMMANDS"
+ls -la "$DIR_GITHUB_RUNNER_FILE_COMMANDS"
+
+endGroup
 
 startGroup "Pull docker image"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -196,7 +196,7 @@ if test -z "$INPUT_CUSTOM_SCRIPT_EXPANDED"; then
 fi
 
 # set permissions for GitHub Actions runner command files
-chmod -R a=u "$DIR_GITHUB_RUNNER_FILE_COMMANDS"
+chmod -R a+rw "$DIR_GITHUB_RUNNER_FILE_COMMANDS"
 
 startGroup "Pull docker image"
 


### PR DESCRIPTION
This should (hopefully) allow the use of things like `>> $GITHUB_OUTPUT` (when such variables are passed through via `export:`)