### PR TITLE
fix: Understand `coq_version: 'latest'` as `rocq/rocq-prover:latest`

### DIFF
--- a/.github/workflows/coq-demo.yml
+++ b/.github/workflows/coq-demo.yml
@@ -26,6 +26,7 @@ jobs:
         # see https://github.com/coq-community/docker-coq/wiki#supported-tags
         coq_version:
           - '8.20'
+          - 'latest'
           - 'latest-native'
           - 'dev'
         ocaml_version: ['default']

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -119,8 +119,7 @@ if test -z "$INPUT_CUSTOM_IMAGE"; then
 
     if [ "${INPUT_COQ_VERSION%%-*}" = 'latest' ]; then
 
-        # TODO: Update once 9.0.0 is released
-        ROCQ_PREFIX="coqorg/coq"
+        ROCQ_PREFIX="rocq/rocq-prover"
 
     elif [ "${INPUT_COQ_VERSION%%.*}" = '8' ]; then
 


### PR DESCRIPTION
Related: https://github.com/coq-community/docker-rocq/pull/11